### PR TITLE
WD-20: Refresh and Deleting Auth

### DIFF
--- a/api/auth.go
+++ b/api/auth.go
@@ -68,6 +68,18 @@ func GetAuth(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, gin.H{"authuid": authuid})
 }
 
+func DeleteAuth(c *gin.Context) {
+	uid := c.Query("uid")
+
+	err := db.DeleteUID(uid)
+	if err != nil {
+		c.IndentedJSON(http.StatusNotFound, gin.H{"message": "user not found"})
+		return
+	}
+
+	c.IndentedJSON(http.StatusOK, gin.H{"message": "deleted"})
+}
+
 func BotAuth(c *gin.Context) {
 	bot_uid, discordID, discord_name := c.Query("botUID"), c.Query("discordID"), c.Query("discordName")
 	if bot_uid != os.Getenv("BOT_UID") {

--- a/api/auth.go
+++ b/api/auth.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"time"
 
 	"app/wenda/db"
 	"app/wenda/utils"
@@ -47,16 +48,20 @@ func GetAuth(c *gin.Context) {
 	json.NewDecoder(resp.Body).Decode(&res)
 
 	token := res["access_token"].(string)
+	refresh_token := res["refresh_token"].(string)
+
 	// Hash the token
 	authuid := utils.HashToken(token)
 
 	discord_id, discord_name := DiscordAuthData(token)
 
 	new_user := db.User{
-		UID:         authuid,
-		Token:       res["access_token"].(string),
-		DiscordID:   discord_id,
-		DiscordName: discord_name,
+		UID:          authuid,
+		Token:        token,
+		DiscordID:    discord_id,
+		DiscordName:  discord_name,
+		RefreshToken: refresh_token,
+		TimeCreated:  time.Now(),
 	}
 
 	err = db.AddUser(new_user)

--- a/db/dynamo.go
+++ b/db/dynamo.go
@@ -31,7 +31,7 @@ func init() {
 
 	// User and task cols
 	user_proj = expression.NamesList(
-		expression.Name("uid"), expression.Name("discordID"), expression.Name("discordName"), expression.Name("token"),
+		expression.Name("uid"), expression.Name("discordID"), expression.Name("discordName"), expression.Name("token"), expression.Name("refreshToken"),
 	)
 	task_proj = expression.NamesList(
 		expression.Name("taskID"), expression.Name("content"), expression.Name("discordID"), expression.Name("lastModified"), expression.Name("taskStatus"), expression.Name("taskDate"), expression.Name("timeCreated"),

--- a/db/schema.go
+++ b/db/schema.go
@@ -11,10 +11,12 @@ const (
 )
 
 type User struct {
-	UID         string `json:"uid"`
-	Token       string `json:"token"`
-	DiscordID   string `json:"discordID"`
-	DiscordName string `json:"discordName"`
+	UID          string    `json:"uid"`
+	Token        string    `json:"token"`
+	DiscordID    string    `json:"discordID"`
+	DiscordName  string    `json:"discordName"`
+	RefreshToken string    `json:"refreshToken"`
+	TimeCreated  time.Time `json:"timeCreated"`
 }
 
 type Task struct {

--- a/db/users_table.go
+++ b/db/users_table.go
@@ -105,6 +105,54 @@ func GetUserToken(uid string) (string, error) {
 	return user.Token, nil
 }
 
+func GetUserRefresh(uid string) (string, error) {
+	user, err := GetUserByUID(uid)
+	if err != nil {
+		log.Printf("Failed to get user %s", err)
+		return "", err
+	}
+	if user == (User{}) {
+		return "", nil
+	}
+	return user.RefreshToken, nil
+}
+
+func UpdateUser(uid string, token string, refresh_token string) error {
+	table_name := "users"
+
+	token_str := "token"
+	input := &dynamodb.UpdateItemInput{
+		ExpressionAttributeValues: map[string]*dynamodb.AttributeValue{
+			":t": {
+				S: aws.String(token),
+			},
+			":refresh": {
+				S: aws.String(refresh_token),
+			},
+		},
+		ExpressionAttributeNames: map[string]*string{
+			"#tok": &token_str,
+		},
+		TableName: aws.String(table_name),
+		Key: map[string]*dynamodb.AttributeValue{
+			"uid": {
+				S: aws.String(uid),
+			},
+		},
+		ReturnValues:     aws.String("UPDATED_NEW"),
+		UpdateExpression: aws.String("set #tok = :t, refreshToken = :refresh"),
+	}
+
+	_, err := svc.UpdateItem(input)
+	if err != nil {
+		log.Printf("Got error calling UpdateItem: %s", err)
+		return err
+	}
+
+	fmt.Println("Successfully updated user " + uid)
+	return nil
+}
+
 func AddUser(user User) error {
 	table_name := "users"
 	err := add_object(user, table_name)

--- a/db/users_table.go
+++ b/db/users_table.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
 	"github.com/aws/aws-sdk-go/service/dynamodb/expression"
@@ -112,5 +113,27 @@ func AddUser(user User) error {
 		return err
 	}
 	fmt.Println("Successfully added " + user.DiscordName + " to table " + table_name)
+	return nil
+}
+
+func DeleteUID(uid string) error {
+	table_name := "users"
+
+	input := &dynamodb.DeleteItemInput{
+		Key: map[string]*dynamodb.AttributeValue{
+			"uid": {
+				S: aws.String(uid),
+			},
+		},
+		TableName: aws.String(table_name),
+	}
+
+	_, err := svc.DeleteItem(input)
+	if err != nil {
+		log.Printf("Got error calling DeleteItem: %s", err)
+		return err
+	}
+
+	fmt.Println("Deleted " + uid)
 	return nil
 }

--- a/handler/router.go
+++ b/handler/router.go
@@ -23,6 +23,7 @@ func bind_discord(router *gin.Engine) {
 
 func bind_auth(router *gin.Engine) {
 	router.GET("/auth", api.GetAuth)
+	router.DELETE("/auth", api.DeleteAuth)
 	router.GET("/botauth", api.BotAuth)
 }
 

--- a/handler/router.go
+++ b/handler/router.go
@@ -24,6 +24,7 @@ func bind_discord(router *gin.Engine) {
 func bind_auth(router *gin.Engine) {
 	router.GET("/auth", api.GetAuth)
 	router.DELETE("/auth", api.DeleteAuth)
+	router.POST("/auth", api.RefreshToken)
 	router.GET("/botauth", api.BotAuth)
 }
 


### PR DESCRIPTION
- DELETE `/auth?uid=...`  will delete the users entry from the dynamodb table
- POST `/auth?uid=...`  will refresh the users token, in case it has expired and update the entry in the dynamodb table (the uid will remain the same)
   - A question to ask is when the token should be refreshed. I have to ways in mind: 
   - 400 error comes in from GET `/user` in the frontend, then it calls this endpoint. 
   - Or perhaps I should check if a 404 comes from the discord endpoint when `/user` is called and handle it purely in the backend
- Updated the user schema to include timeCreated and refreshToken (old UIDs will not work w refreshing)